### PR TITLE
Changed script execution to use local env

### DIFF
--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$#" == 0 ] || [ "$1" == "googlenet" ]; then
     curl "http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel" -o models/googlenet/bvlc_googlenet.caffemodel


### PR DESCRIPTION
Using /usr/bin/env makes the user's PATH variable available to the script.
This resolves issues where /usr/bin/bash might not be the actual bash a user has installed. Or does not even exist but is under i.e. /usr/local/bin/bash